### PR TITLE
Don't run asm.js through babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@babel/core": "^7.5.4",
     "@polkadot/dev": "^0.30.0-beta.23",
-    "@polkadot/util": "^0.94.0-beta.17",
+    "@polkadot/util": "^0.94.0-beta.18",
     "override-require": "^1.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2030,10 +2030,10 @@
     typescript "^3.5.3"
     vuepress "^1.0.2"
 
-"@polkadot/util@^0.94.0-beta.17":
-  version "0.94.0-beta.17"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-0.94.0-beta.17.tgz#998a0cb69d7005d4fcb0c94a9d2db1fa48ae584b"
-  integrity sha512-NYZF1gN4Yr31uMJe9x6MSTuvBOPn3NOH2RTs5Juz4wCG6Q2ejjPk0l3HG4/6rDq5Uh+x/zw3DREpayBpN36ihw==
+"@polkadot/util@^0.94.0-beta.18":
+  version "0.94.0-beta.18"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-0.94.0-beta.18.tgz#363581e1092a1972d1f14df0db18d85a3a27f380"
+  integrity sha512-SzcKGFeskHQMdrZDnsRQ72lFYkUBWAJBAhjMrpUZR0iMvOSnjaX663034PLr3hvUKunh9W6NjQHJAOrpBgaFfA==
   dependencies:
     "@babel/runtime" "^7.5.5"
     "@types/bn.js" "^4.11.5"


### PR DESCRIPTION
Related to https://github.com/polkadot-js/wasm/issues/19

This will speed up processing since the same file won't be run through babel multiple times. (Let the final bundler handle the packaging.) This means the output is as close to the `wasm2js` output as possible, only adjustments are in the imports and exports.