### PR TITLE
Use lz4 on the WASM stream

### DIFF
--- a/packages/bytes-wasm-crypto/package.json
+++ b/packages/bytes-wasm-crypto/package.json
@@ -12,6 +12,7 @@
   "bugs": "https://github.com/polkadot-js/wasm/issues",
   "homepage": "https://github.com/polkadot-js/wasm",
   "dependencies": {
-    "@babel/runtime": "^7.12.5"
+    "@babel/runtime": "^7.12.5",
+    "lz4js": "^0.2.0"
   }
 }

--- a/packages/bytes-wasm-crypto/package.json
+++ b/packages/bytes-wasm-crypto/package.json
@@ -13,7 +13,6 @@
   "homepage": "https://github.com/polkadot-js/wasm",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "fflate": "^0.4.2",
-    "lz4js": "^0.2.0"
+    "fflate": "^0.4.2"
   }
 }

--- a/packages/bytes-wasm-crypto/package.json
+++ b/packages/bytes-wasm-crypto/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/polkadot-js/wasm",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
+    "fflate": "^0.4.2",
     "lz4js": "^0.2.0"
   }
 }

--- a/packages/bytes-wasm-crypto/src/buffer.ts
+++ b/packages/bytes-wasm-crypto/src/buffer.ts
@@ -1,0 +1,4 @@
+// Copyright 2017-2020 @polkadot/bytes-wasm-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export const buffer = Buffer.from([]);

--- a/packages/bytes-wasm-crypto/src/data.ts
+++ b/packages/bytes-wasm-crypto/src/data.ts
@@ -1,4 +1,8 @@
 // Copyright 2017-2020 @polkadot/bytes-wasm-crypto authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export const wasmBytes = null;
+import { unzlibSync } from 'fflate';
+
+import { buffer } from './buffer';
+
+export const wasmBytes = unzlibSync(buffer);

--- a/packages/wasm-crypto/package.json
+++ b/packages/wasm-crypto/package.json
@@ -10,8 +10,8 @@
   },
   "devDependencies": {
     "@polkadot/dev": "^0.60.29",
-    "@polkadot/util": "^4.2.2-14",
-    "@polkadot/x-randomvalues": "^4.2.2-14",
+    "@polkadot/util": "^4.2.2-15",
+    "@polkadot/x-randomvalues": "^4.2.2-15",
     "override-require": "^1.1.1"
   },
   "peerDependencies": {

--- a/scripts/pack-wasm-base.js
+++ b/scripts/pack-wasm-base.js
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 const fs = require('fs');
-const lz4 = require('lz4js');
 const { formatNumber } = require('@polkadot/util');
 
 const A_NAME = 'bytes-asmjs-crypto';
@@ -16,11 +15,16 @@ function hdr (package) {
 `;
 }
 
-function getWasmBuffer () {
+// only one of the deps are included, here are the details for package.json -
+//   "fflate": "^0.4.2"
+//   "lz4js": "^0.2.0"
+function getWasmBuffer (lib = 'fflate') {
   const data = fs.readFileSync('./bytes/wasm_opt.wasm');
-  const comp = Buffer.from(lz4.compress(data));
+  const comp = lib === 'fflate'
+    ? Buffer.from(require('fflate').zlibSync(data, { level: 9 }))
+    : Buffer.from(require('lz4js').compress(data));
 
-  console.log(`*** Compressed WASM ${formatNumber(data.length)} -> ${formatNumber(comp.length)} (${(100 * comp.length / data.length).toFixed(2)}%)`);
+  console.log(`*** Compressed WASM via ${lib}: ${formatNumber(data.length)} -> ${formatNumber(comp.length)} (${(100 * comp.length / data.length).toFixed(2)}%)`);
 
   return comp.toString('base64');
 }
@@ -29,14 +33,12 @@ fs.writeFileSync(`./${A_NAME}/build/data.mjs`, `${hdr(A_NAME)}
 export { asmJsInit } from './data.js';
 `);
 
-fs.writeFileSync(`./${W_NAME}/build/data.mjs`, `${hdr(W_NAME)}
-export { wasmBytes } from './data.js';
+fs.writeFileSync(`./${W_NAME}/build/buffer.mjs`, `${hdr(W_NAME)}
+export { buffer } from './buffer.js';
 `);
 
-fs.writeFileSync('./bytes-wasm-crypto/build/data.js', `${hdr(W_NAME)}
-const lz4 = require('lz4js');
+fs.writeFileSync('./bytes-wasm-crypto/build/buffer.js', `${hdr(W_NAME)}
+const buffer = Buffer.from('${getWasmBuffer()}', 'base64');
 
-const wasmBytes = lz4.decompress(Buffer.from('${getWasmBuffer()}', 'base64'));
-
-module.exports = { wasmBytes };
+module.exports = { buffer };
 `);

--- a/scripts/pack-wasm-base.js
+++ b/scripts/pack-wasm-base.js
@@ -2,15 +2,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 const fs = require('fs');
+const lz4 = require('lz4js');
+const { formatNumber } = require('@polkadot/util');
 
 const A_NAME = 'bytes-asmjs-crypto';
 const W_NAME = 'bytes-wasm-crypto';
 
-const hdr = (package) => `// Copyright 2019-2020 @polkadot/${package} authors & contributors
+function hdr (package) {
+  return `// Copyright 2019-2020 @polkadot/${package} authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Generated as part of the build, do not edit
 `;
+}
+
+function getWasmBuffer () {
+  const data = fs.readFileSync('./bytes/wasm_opt.wasm');
+  const comp = Buffer.from(lz4.compress(data));
+
+  console.log(`*** Compressed WASM ${formatNumber(data.length)} -> ${formatNumber(comp.length)} (${(100 * comp.length / data.length).toFixed(2)}%)`);
+
+  return comp.toString('base64');
+}
 
 fs.writeFileSync(`./${A_NAME}/build/data.mjs`, `${hdr(A_NAME)}
 export { asmJsInit } from './data.js';
@@ -21,5 +34,9 @@ export { wasmBytes } from './data.js';
 `);
 
 fs.writeFileSync('./bytes-wasm-crypto/build/data.js', `${hdr(W_NAME)}
-module.exports = { wasmBytes: Buffer.from('${fs.readFileSync('./bytes/wasm_opt.wasm').toString('base64')}', 'base64') };
+const lz4 = require('lz4js');
+
+const wasmBytes = lz4.decompress(Buffer.from('${getWasmBuffer()}', 'base64'));
+
+module.exports = { wasmBytes };
 `);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1699,6 +1699,7 @@ __metadata:
   resolution: "@polkadot/bytes-wasm-crypto@workspace:packages/bytes-wasm-crypto"
   dependencies:
     "@babel/runtime": ^7.12.5
+    fflate: ^0.4.2
     lz4js: ^0.2.0
   languageName: unknown
   linkType: soft
@@ -4454,6 +4455,13 @@ __metadata:
   dependencies:
     bser: 2.1.1
   checksum: f9ec24592a45026a6a7f54034a4b5efb010cac7d7fbc234fe9ae5d725c13efa9be0ded1ae348473fc42af4e28eea53f8b993857c0c49e6d721f7c9eb5b21217f
+  languageName: node
+  linkType: hard
+
+"fflate@npm:^0.4.2":
+  version: 0.4.2
+  resolution: "fflate@npm:0.4.2"
+  checksum: e96c19a1d514f74faa1fe320c022aaf1dade597150510da18dce024ff5a2fa0b6e103daf828fac26c54b647777256638fc7106a3dcff078572b8dee73071df54
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1700,7 +1700,6 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.12.5
     fflate: ^0.4.2
-    lz4js: ^0.2.0
   languageName: unknown
   linkType: soft
 
@@ -6823,13 +6822,6 @@ fsevents@~2.1.2:
   version: 2.3.9
   resolution: "lunr@npm:2.3.9"
   checksum: a2b66320c2f6632322b91c43621eed9e623c0f1b81e7c2d74c238884a02229698baa4478bd238e9b32d7abf0db5ae9233b311c28e1edbcc481774e1ce83bec6f
-  languageName: node
-  linkType: hard
-
-"lz4js@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "lz4js@npm:0.2.0"
-  checksum: bbad1b4c5aa9077050125958b7013a9c400ca75eb269976c2074b5b1b57f773e25a6f11efd88a491b115ae91cecac0f8a4ce299492296f3348fdc940c1dcc5ad
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1699,6 +1699,7 @@ __metadata:
   resolution: "@polkadot/bytes-wasm-crypto@workspace:packages/bytes-wasm-crypto"
   dependencies:
     "@babel/runtime": ^7.12.5
+    lz4js: ^0.2.0
   languageName: unknown
   linkType: soft
 
@@ -1796,18 +1797,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:^4.2.2-14":
-  version: 4.2.2-14
-  resolution: "@polkadot/util@npm:4.2.2-14"
+"@polkadot/util@npm:^4.2.2-15":
+  version: 4.2.2-15
+  resolution: "@polkadot/util@npm:4.2.2-15"
   dependencies:
     "@babel/runtime": ^7.12.5
-    "@polkadot/x-textdecoder": 4.2.2-14
-    "@polkadot/x-textencoder": 4.2.2-14
+    "@polkadot/x-textdecoder": 4.2.2-15
+    "@polkadot/x-textencoder": 4.2.2-15
     "@types/bn.js": ^4.11.6
     bn.js: ^4.11.9
     camelcase: ^5.3.1
     ip-regex: ^4.2.0
-  checksum: bfe13736649b08eb08dbc6cf4a312ef13d6baf179755ecf918cc4b20ed673a551a4e0e0c95a641745a4627d14101c27759247d9f06878457f9cc4d8000a6eb70
+  checksum: 268630b60794bcaf6626ba3aee209f7418fecf1417cd985a18cbc25ec0d692a63344cb67f6aaeca395a9ad2fa6e175eed1de921123c20a45ff78e299e5b92041
   languageName: node
   linkType: hard
 
@@ -1819,8 +1820,8 @@ __metadata:
     "@polkadot/bytes-asmjs-crypto": ^2.0.2-15
     "@polkadot/bytes-wasm-crypto": ^2.0.2-15
     "@polkadot/dev": ^0.60.29
-    "@polkadot/util": ^4.2.2-14
-    "@polkadot/x-randomvalues": ^4.2.2-14
+    "@polkadot/util": ^4.2.2-15
+    "@polkadot/x-randomvalues": ^4.2.2-15
     override-require: ^1.1.1
   peerDependencies:
     "@polkadot/util": "*"
@@ -1828,30 +1829,30 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/x-randomvalues@npm:^4.2.2-14":
-  version: 4.2.2-14
-  resolution: "@polkadot/x-randomvalues@npm:4.2.2-14"
+"@polkadot/x-randomvalues@npm:^4.2.2-15":
+  version: 4.2.2-15
+  resolution: "@polkadot/x-randomvalues@npm:4.2.2-15"
   dependencies:
     "@babel/runtime": ^7.12.5
-  checksum: b8beaf8371334237607832d6e5e19291c03afcf533fff9ddd6e218e51d94273de5b534afd5b57eca31795165b3771f4f308299391299807f833bbce50776f323
+  checksum: 2dcde33e485f6b5f01164d926a31871569f53d31ce9c9a374c99883b142942b127b6bf2050d5b22104af6c1493ff0bdb99bae941644225c7bb718a39c8f43096
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:4.2.2-14":
-  version: 4.2.2-14
-  resolution: "@polkadot/x-textdecoder@npm:4.2.2-14"
+"@polkadot/x-textdecoder@npm:4.2.2-15":
+  version: 4.2.2-15
+  resolution: "@polkadot/x-textdecoder@npm:4.2.2-15"
   dependencies:
     "@babel/runtime": ^7.12.5
-  checksum: 0516ef3abd8e04fe964f6d2aa95a09c80f9f6d8b3d1a62b9df2aae004393c1660ec5d18ce8be23f61043d0cc9903920731b598d5dd1c49f9f1be8d9ee955684f
+  checksum: 613e253033947c0049798302226d68941b4cf6a3cd60372766578d13ece7b319d93ddd69e7179f49461031ba0bbed8fc93126157e2cc95afbb5b107c80822e3c
   languageName: node
   linkType: hard
 
-"@polkadot/x-textencoder@npm:4.2.2-14":
-  version: 4.2.2-14
-  resolution: "@polkadot/x-textencoder@npm:4.2.2-14"
+"@polkadot/x-textencoder@npm:4.2.2-15":
+  version: 4.2.2-15
+  resolution: "@polkadot/x-textencoder@npm:4.2.2-15"
   dependencies:
     "@babel/runtime": ^7.12.5
-  checksum: 2d9c66b1e6e5e5ceb06c552f48f51bb38e881a77a7134a08ab2d725ab42612964234564064d6fb1d47de6d831469b23f9af3662a18867fe4c50cbd9258279c08
+  checksum: a7541e899be2375b4cb1913896e7acbc774fcd891947c53d540afd8ebfcca2216c8f31a84e428d88506dda5325369584b7b7e32559b0e6b91e34644884fc0a2c
   languageName: node
   linkType: hard
 
@@ -6814,6 +6815,13 @@ fsevents@~2.1.2:
   version: 2.3.9
   resolution: "lunr@npm:2.3.9"
   checksum: a2b66320c2f6632322b91c43621eed9e623c0f1b81e7c2d74c238884a02229698baa4478bd238e9b32d7abf0db5ae9233b311c28e1edbcc481774e1ce83bec6f
+  languageName: node
+  linkType: hard
+
+"lz4js@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "lz4js@npm:0.2.0"
+  checksum: bbad1b4c5aa9077050125958b7013a9c400ca75eb269976c2074b5b1b57f773e25a6f11efd88a491b115ae91cecac0f8a4ce299492296f3348fdc940c1dcc5ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Just a POC, so some good, some bad. The actual WASM bytes compress to 68% (lz4), however this does come at a cost as well - while the bundle seems smaller, do remember that in the case of web, the JS is typically served compressed. So actually at the end you have slightly more bytes coming across the wire (lz4 doesn't gzip/broccoli very well).

So in 2 minds, it _seems_ smaller, but -

- it is most probably a cosmetic things, not actual real-world
- there is a very small (lz4 is very fast) decompress phase, but this probably cancels out with less bytes being base64 decoded (so tiny delay, but neglible)

Anyway, here are some stats as per the WASM bytes output - 

- lz4: 284,502 -> 196,104 (68.93%)
- fflate: 284,502 -> 146,317 (51.43%)

The second is interesting, since we actually do get real-world performance here. The stream, since it is statically encoded, gets done with level 9. So it is actually smaller and the overall bundle transferred is also smaller overall.

For fflate the lib is slightly larger, however it also allows for tree-shaking, which ends up with a smaller actual per-use size.