### PR TITLE
Bundle unzlibSync (no worker requirement, stop-gap)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
-    "@polkadot/dev": "^0.61.11"
+    "@polkadot/dev": "^0.61.12",
+    "fflate": "^0.4.3"
   },
   "version": "3.0.2-11"
 }

--- a/packages/wasm-crypto-wasm/package.json
+++ b/packages/wasm-crypto-wasm/package.json
@@ -14,7 +14,6 @@
   "bugs": "https://github.com/polkadot-js/wasm/issues",
   "homepage": "https://github.com/polkadot-js/wasm",
   "dependencies": {
-    "@babel/runtime": "^7.12.5",
-    "fflate": "^0.4.2"
+    "@babel/runtime": "^7.12.5"
   }
 }

--- a/packages/wasm-crypto-wasm/src/buffer.ts
+++ b/packages/wasm-crypto-wasm/src/buffer.ts
@@ -2,3 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export const buffer = Buffer.from([]);
+
+export const sizeCompressed = 0;
+
+export const sizeUncompressed = 0;

--- a/packages/wasm-crypto-wasm/src/data.ts
+++ b/packages/wasm-crypto-wasm/src/data.ts
@@ -1,9 +1,7 @@
 // Copyright 2017-2020 @polkadot/wasm-crypto-wasm authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// import { unzlibSync } from 'fflate';
-
-import { buffer } from './buffer';
+import { buffer, sizeUncompressed } from './buffer';
 import { unzlibSync } from './fflate';
 
-export const wasmBytes = unzlibSync(buffer);
+export const wasmBytes = unzlibSync(buffer, new Uint8Array(sizeUncompressed));

--- a/packages/wasm-crypto-wasm/src/data.ts
+++ b/packages/wasm-crypto-wasm/src/data.ts
@@ -1,8 +1,9 @@
 // Copyright 2017-2020 @polkadot/wasm-crypto-wasm authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { unzlibSync } from 'fflate';
+// import { unzlibSync } from 'fflate';
 
 import { buffer } from './buffer';
+import { unzlibSync } from './fflate';
 
 export const wasmBytes = unzlibSync(buffer);

--- a/packages/wasm-crypto-wasm/src/fflate.ts
+++ b/packages/wasm-crypto-wasm/src/fflate.ts
@@ -1,0 +1,342 @@
+// Copyright 2017-2020 @polkadot/wasm-crypto authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// MIT License
+//
+// Copyright (c) 2020 Arjun Barrett
+//
+// Copied from https://github.com/101arrowz/fflate/blob/73c737941ec89d85cdf0ad39ee6f26c5fdc95fd7/src/index.ts
+// This only contains the unzlibSync function, no compression, no async, no workers
+//
+// These 2 issues are addressed as a short-term, stop-gap solution
+//   - https://github.com/polkadot-js/api/issues/2963
+//   - https://github.com/101arrowz/fflate/issues/17
+//
+// Only tweaks make here are some TS adjustments (we use strict null checks), the code is otherwise as-is with
+// only the single required function provided (compression is still being done in the build with fflate)
+
+/* eslint-disable */
+
+// inflate state
+type InflateState = {
+  // lmap
+  l?: Uint16Array;
+  // dmap
+  d?: Uint16Array;
+  // lbits
+  m?: number;
+  // dbits
+  n?: number;
+  // final
+  f?: number;
+  // pos
+  p?: number;
+  // byte
+  b?: number;
+  // lstchk
+  i?: boolean;
+};
+
+// aliases for shorter compressed code (most minifers don't do this)
+const u8 = Uint8Array, u16 = Uint16Array, u32 = Uint32Array;
+
+// code length index map
+const clim = new u8([16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15]);
+
+// fixed length extra bits
+const fleb = new u8([0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0, /* unused */ 0, 0, /* impossible */ 0]);
+
+// fixed distance extra bits
+// see fleb note
+const fdeb = new u8([0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, /* unused */ 0, 0]);
+
+// get base, reverse index map from extra bits
+const freb = (eb: Uint8Array, start: number) => {
+  const b = new u16(31);
+  for (let i = 0; i < 31; ++i) {
+    b[i] = start += 1 << eb[i - 1];
+  }
+  // numbers here are at max 18 bits
+  const r = new u32(b[30]);
+  for (let i = 1; i < 30; ++i) {
+    for (let j = b[i]; j < b[i + 1]; ++j) {
+      r[j] = ((j - b[i]) << 5) | i;
+    }
+  }
+  return [b, r] as const;
+}
+
+const [fl, revfl] = freb(fleb, 2);
+// we can ignore the fact that the other numbers are wrong; they never happen anyway
+fl[28] = 258, revfl[258] = 28;
+const [fd] = freb(fdeb, 0);
+
+// map of value to reverse (assuming 16 bits)
+const rev = new u16(32768);
+for (let i = 0; i < 32768; ++i) {
+  // reverse table algorithm from SO
+  let x = ((i & 0xAAAA) >>> 1) | ((i & 0x5555) << 1);
+  x = ((x & 0xCCCC) >>> 2) | ((x & 0x3333) << 2);
+  x = ((x & 0xF0F0) >>> 4) | ((x & 0x0F0F) << 4);
+  rev[i] = (((x & 0xFF00) >>> 8) | ((x & 0x00FF) << 8)) >>> 1;
+}
+
+// create huffman tree from u8 "map": index -> code length for code index
+// mb (max bits) must be at most 15
+// TODO: optimize/split up?
+const hMap = ((cd: Uint8Array, mb: number, r: 0 | 1) => {
+  const s = cd.length;
+  // index
+  let i = 0;
+  // u16 "map": index -> # of codes with bit length = index
+  const l = new u16(mb);
+  // length of cd must be 288 (total # of codes)
+  for (; i < s; ++i) ++l[cd[i] - 1];
+  // u16 "map": index -> minimum code for bit length = index
+  const le = new u16(mb);
+  for (i = 0; i < mb; ++i) {
+    le[i] = (le[i - 1] + l[i - 1]) << 1;
+  }
+  let co: Uint16Array;
+  if (r) {
+    // u16 "map": index -> number of actual bits, symbol for code
+    co = new u16(1 << mb);
+    // bits to remove for reverser
+    const rvb = 15 - mb;
+    for (i = 0; i < s; ++i) {
+      // ignore 0 lengths
+      if (cd[i]) {
+        // num encoding both symbol and bits read
+        const sv = (i << 4) | cd[i];
+        // free bits
+        const r = mb - cd[i];
+        // start value
+        let v = le[cd[i] - 1]++ << r;
+        // m is end value
+        for (const m = v | ((1 << r) - 1); v <= m; ++v) {
+          // every 16 bit value starting with the code yields the same result
+          co[rev[v] >>> rvb] = sv;
+        }
+      }
+    }
+  } else {
+    co = new u16(s);
+    for (i = 0; i < s; ++i) co[i] = rev[le[cd[i] - 1]++] >>> (15 - cd[i]);
+  }
+  return co;
+});
+
+// fixed length tree
+const flt = new u8(288);
+for (let i = 0; i < 144; ++i) flt[i] = 8;
+for (let i = 144; i < 256; ++i) flt[i] = 9;
+for (let i = 256; i < 280; ++i) flt[i] = 7;
+for (let i = 280; i < 288; ++i) flt[i] = 8;
+// fixed distance tree
+const fdt = new u8(32);
+for (let i = 0; i < 32; ++i) fdt[i] = 5;
+
+// fixed length map
+const flrm = hMap(flt, 9, 1);
+// fixed distance map
+const fdrm = hMap(fdt, 5, 1);
+
+// read d, starting at bit p and mask with m
+const bits = (d: Uint8Array, p: number, m: number) => {
+  const o = p >>> 3;
+  return ((d[o] | (d[o + 1] << 8)) >>> (p & 7)) & m;
+}
+
+// read d, starting at bit p continuing for at least 16 bits
+const bits16 = (d: Uint8Array, p: number) => {
+  const o = p >>> 3;
+  return ((d[o] | (d[o + 1] << 8) | (d[o + 2] << 16)) >>> (p & 7));
+}
+
+// get end of byte
+const shft = (p: number) => (p >>> 3) + (p & 7 && 1);
+
+// typed array slice - allows garbage collector to free original reference,
+// while being more compatible than .slice
+const slc = <T extends Uint8Array | Uint16Array | Uint32Array>(v: T, s: number, e?: number): T => {
+  if (s == null || s < 0) s = 0;
+  if (e == null || e > v.length) e = v.length;
+  // can't use .constructor in case user-supplied
+  const n = new (v instanceof u16 ? u16 : v instanceof u32 ? u32 : u8)(e - s) as T;
+  n.set(v.subarray(s, e));
+  return n;
+}
+
+// find max of array
+const max = (a: Uint8Array | number[]) => {
+  let m = a[0];
+  for (let i = 1; i < a.length; ++i) {
+    if (a[i] > m) m = a[i];
+  }
+  return m;
+};
+
+// expands raw DEFLATE data
+const inflt = (dat: Uint8Array, buf?: Uint8Array, st?: InflateState) => {
+  const noSt = !st || st.i;
+  if (!st) st = {};
+  // source length
+  const sl = dat.length;
+  // have to estimate size
+  const noBuf = !buf || !noSt;
+  // Assumes roughly 33% compression ratio average
+  if (!buf) buf = new u8(sl * 3);
+  // ensure buffer can fit at least l elements
+  const cbuf = (l: number) => {
+    let bl = buf!.length;
+    // need to increase size to fit
+    if (l > bl) {
+      // Double or set to necessary, whichever is greater
+      const nbuf = new u8(Math.max(bl << 1, l));
+      nbuf.set(buf!);
+      buf = nbuf;
+    }
+  };
+  //  last chunk         bitpos           bytes
+  let final = st.f || 0, pos = st.p || 0, bt = st.b || 0, lm = st.l, dm = st.d, lbt = st.m, dbt = st.n;
+  if (final && !lm) return buf;
+  // total bits
+  const tbts = sl << 3;
+  do {
+    if (!lm) {
+      // BFINAL - this is only 1 when last chunk is next
+      st.f = final = bits(dat, pos, 1);
+      // type: 0 = no compression, 1 = fixed huffman, 2 = dynamic huffman
+      const type = bits(dat, pos + 1, 3);
+      pos += 3;
+      if (!type) {
+        // go to end of byte boundary
+        const s = shft(pos) + 4, l = dat[s - 4] | (dat[s - 3] << 8), t = s + l;
+        if (t > sl) {
+          if (noSt) throw 'unexpected EOF';
+          break;
+        }
+        // ensure size
+        if (noBuf) cbuf(bt + l);
+        // Copy over uncompressed data
+        buf.set(dat.subarray(s, t), bt);
+        // Get new bitpos, update byte count
+        st.b = bt += l, st.p = pos = t << 3;
+        continue;
+      }
+      else if (type == 1) lm = flrm, dm = fdrm, lbt = 9, dbt = 5;
+      else if (type == 2) {
+        //  literal                            lengths
+        const hLit = bits(dat, pos, 31) + 257, hcLen = bits(dat, pos + 10, 15) + 4;
+        const tl = hLit + bits(dat, pos + 5, 31) + 1;
+        pos += 14;
+        // length+distance tree
+        const ldt = new u8(tl);
+        // code length tree
+        const clt = new u8(19);
+        for (let i = 0; i < hcLen; ++i) {
+          // use index map to get real code
+          clt[clim[i]] = bits(dat, pos + i * 3, 7);
+        }
+        pos += hcLen * 3;
+        // code lengths bits
+        const clb = max(clt), clbmsk = (1 << clb) - 1;
+        if (!noSt && pos + tl * (clb + 7) > tbts) break;
+        // code lengths map
+        const clm = hMap(clt, clb, 1);
+        for (let i = 0; i < tl;) {
+          const r = clm[bits(dat, pos, clbmsk)];
+          // bits read
+          pos += r & 15;
+          // symbol
+          const s = r >>> 4;
+          // code length to copy
+          if (s < 16) {
+            ldt[i++] = s;
+          } else {
+            //  copy   count
+            let c = 0, n = 0;
+            if (s == 16) n = 3 + bits(dat, pos, 3), pos += 2, c = ldt[i - 1];
+            else if (s == 17) n = 3 + bits(dat, pos, 7), pos += 3;
+            else if (s == 18) n = 11 + bits(dat, pos, 127), pos += 7;
+            while (n--) ldt[i++] = c;
+          }
+        }
+        //    length tree                 distance tree
+        const lt = ldt.subarray(0, hLit), dt = ldt.subarray(hLit);
+        // max length bits
+        lbt = max(lt)
+        // max dist bits
+        dbt = max(dt);
+        lm = hMap(lt, lbt, 1);
+        dm = hMap(dt, dbt, 1);
+      } else throw 'invalid block type';
+      if (pos > tbts) throw 'unexpected EOF';
+    }
+    // Make sure the buffer can hold this + the largest possible addition
+    // maximum chunk size (practically, theoretically infinite) is 2^17;
+    if (noBuf) cbuf(bt + 131072);
+    const lms = (1 << lbt!) - 1, dms = (1 << dbt!) - 1;
+    const mxa = lbt! + dbt! + 18;
+    while (noSt || pos + mxa < tbts) {
+      // bits read, code
+      const c = lm[bits16(dat, pos) & lms], sym = c >>> 4;
+      pos += c & 15;
+      if (pos > tbts) throw 'unexpected EOF';
+      if (!c) throw 'invalid length/literal';
+      if (sym < 256) buf[bt++] = sym;
+      else if (sym == 256) {
+        lm = undefined;
+        break;
+      }
+      else {
+        let add = sym - 254;
+        // no extra bits needed if less
+        if (sym > 264) {
+          // index
+          const i = sym - 257, b = fleb[i];
+          add = bits(dat, pos, (1 << b) - 1) + fl[i];
+          pos += b;
+        }
+        // dist
+        const d = dm![bits16(dat, pos) & dms], dsym = d >>> 4;
+        if (!d) throw 'invalid distance';
+        pos += d & 15;
+        let dt = fd[dsym];
+        if (dsym > 3) {
+          const b = fdeb[dsym];
+          dt += bits16(dat, pos) & ((1 << b) - 1), pos += b;
+        }
+        if (pos > tbts) throw 'unexpected EOF';
+        if (noBuf) cbuf(bt + 131072);
+        const end = bt + add;
+        for (; bt < end; bt += 4) {
+          buf[bt] = buf[bt - dt];
+          buf[bt + 1] = buf[bt + 1 - dt];
+          buf[bt + 2] = buf[bt + 2 - dt];
+          buf[bt + 3] = buf[bt + 3 - dt];
+        }
+        bt = end;
+      }
+    }
+    st.l = lm, st.p = pos, st.b = bt;
+    if (lm) final = 1, st.m = lbt, st.d = dm, st.n = dbt;
+  } while (!final)
+  return bt == buf.length ? buf : slc(buf, 0, bt);
+}
+
+// zlib valid
+const zlv = (d: Uint8Array) => {
+  if ((d[0] & 15) != 8 || (d[0] >>> 4) > 7 || ((d[0] << 8 | d[1]) % 31)) throw 'invalid zlib data';
+  if (d[1] & 32) throw 'invalid zlib data: preset dictionaries not supported';
+}
+
+/**
+ * Expands Zlib data
+ * @param data The data to decompress
+ * @param out Where to write the data. Saves memory if you know the decompressed size and provide an output buffer of that length.
+ * @returns The decompressed version of the data
+ */
+export function unzlibSync(data: Uint8Array, out?: Uint8Array) {
+  return inflt((zlv(data), data.subarray(2, -4)), out);
+}

--- a/packages/wasm-crypto/package.json
+++ b/packages/wasm-crypto/package.json
@@ -14,9 +14,9 @@
     "@polkadot/wasm-crypto-wasm": "^3.0.2-11"
   },
   "devDependencies": {
-    "@polkadot/dev": "^0.61.11",
-    "@polkadot/util": "^5.0.2-7",
-    "@polkadot/x-randomvalues": "^5.0.2-7",
+    "@polkadot/dev": "^0.61.12",
+    "@polkadot/util": "^5.0.2-8",
+    "@polkadot/x-randomvalues": "^5.0.2-8",
     "override-require": "^1.1.1"
   },
   "peerDependencies": {

--- a/scripts/pack-wasm-base.js
+++ b/scripts/pack-wasm-base.js
@@ -34,7 +34,7 @@ export { asmJsInit } from './data.js';
 `);
 
 fs.writeFileSync(`./${W_NAME}/build/buffer.mjs`, `${hdr(W_NAME)}
-export { buffer } from './buffer.js';
+export { buffer, sizeCompressed, sizeUncompressed } from './buffer.js';
 `);
 
 const { compressed, sizeUncompressed } = getWasmBuffer();

--- a/scripts/pack-wasm-base.js
+++ b/scripts/pack-wasm-base.js
@@ -20,13 +20,13 @@ function hdr (package) {
 //   "lz4js": "^0.2.0"
 function getWasmBuffer (lib = 'fflate') {
   const data = fs.readFileSync('./bytes/wasm_opt.wasm');
-  const comp = lib === 'fflate'
+  const compressed = lib === 'fflate'
     ? Buffer.from(require('fflate').zlibSync(data, { level: 9 }))
     : Buffer.from(require('lz4js').compress(data));
 
-  console.log(`*** Compressed WASM via ${lib}: ${formatNumber(data.length)} -> ${formatNumber(comp.length)} (${(100 * comp.length / data.length).toFixed(2)}%)`);
+  console.log(`*** Compressed WASM via ${lib}: ${formatNumber(data.length)} -> ${formatNumber(compressed.length)} (${(100 * compressed.length / data.length).toFixed(2)}%)`);
 
-  return comp.toString('base64');
+  return { compressed, sizeUncompressed: data.length };
 }
 
 fs.writeFileSync(`./${A_NAME}/build/data.mjs`, `${hdr(A_NAME)}
@@ -37,8 +37,12 @@ fs.writeFileSync(`./${W_NAME}/build/buffer.mjs`, `${hdr(W_NAME)}
 export { buffer } from './buffer.js';
 `);
 
-fs.writeFileSync(`./${W_NAME}/build/buffer.js`, `${hdr(W_NAME)}
-const buffer = Buffer.from('${getWasmBuffer()}', 'base64');
+const { compressed, sizeUncompressed } = getWasmBuffer();
 
-module.exports = { buffer };
+fs.writeFileSync(`./${W_NAME}/build/buffer.js`, `${hdr(W_NAME)}
+const sizeCompressed = ${compressed.length};
+const sizeUncompressed = ${sizeUncompressed};
+const buffer = Buffer.from('${compressed.toString('base64')}', 'base64');
+
+module.exports = { buffer, sizeCompressed, sizeUncompressed };
 `);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1686,9 +1686,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/dev@npm:^0.61.11":
-  version: 0.61.11
-  resolution: "@polkadot/dev@npm:0.61.11"
+"@polkadot/dev@npm:^0.61.12":
+  version: 0.61.12
+  resolution: "@polkadot/dev@npm:0.61.12"
   dependencies:
     "@babel/cli": ^7.12.10
     "@babel/core": ^7.12.10
@@ -1775,22 +1775,22 @@ __metadata:
     polkadot-exec-typedoc: scripts/polkadot-exec-typedoc.cjs
     polkadot-exec-vuepress: scripts/polkadot-exec-vuepress.cjs
     polkadot-exec-webpack: scripts/polkadot-exec-webpack.cjs
-  checksum: f8ada082831cf62bbf353c1aab5a3e9c3cdef901aede558bb76f22199cf042a9423c4cbb902bb4fc0f5dffd4cd91d7b807dfec8c5742a00ca83412dda0bc5332
+  checksum: 7122a2a5a9e61cc98120147a632b23633096bb638e916f294721154428b8cff78ee4eb75b2ddac0762cf611f8c970a71dbc90e77cc5e42cf14a47b2d812615d8
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:^5.0.2-7":
-  version: 5.0.2-7
-  resolution: "@polkadot/util@npm:5.0.2-7"
+"@polkadot/util@npm:^5.0.2-8":
+  version: 5.0.2-8
+  resolution: "@polkadot/util@npm:5.0.2-8"
   dependencies:
     "@babel/runtime": ^7.12.5
-    "@polkadot/x-textdecoder": 5.0.2-7
-    "@polkadot/x-textencoder": 5.0.2-7
+    "@polkadot/x-textdecoder": 5.0.2-8
+    "@polkadot/x-textencoder": 5.0.2-8
     "@types/bn.js": ^4.11.6
     bn.js: ^4.11.9
     camelcase: ^5.3.1
     ip-regex: ^4.2.0
-  checksum: d39af228db24fcb38fe25d9c8d11ffa0eb87478fc7bfbbb53bdb53cc51a5d2f17c4176e8a0884fc43d7135c297436c2250c718063f4d44ae93018245b82b250e
+  checksum: b7ababe3f8c039b9bc398dfb806b6b451e3a5946faa72dc722d3b990b894e87c7195e0c53adfdfbe98e01d6370a68547779822673d4b87d228a13f5d277dceb8
   languageName: node
   linkType: hard
 
@@ -1807,7 +1807,6 @@ __metadata:
   resolution: "@polkadot/wasm-crypto-wasm@workspace:packages/wasm-crypto-wasm"
   dependencies:
     "@babel/runtime": ^7.12.5
-    fflate: ^0.4.2
   languageName: unknown
   linkType: soft
 
@@ -1816,11 +1815,11 @@ __metadata:
   resolution: "@polkadot/wasm-crypto@workspace:packages/wasm-crypto"
   dependencies:
     "@babel/runtime": ^7.12.5
-    "@polkadot/dev": ^0.61.11
-    "@polkadot/util": ^5.0.2-7
+    "@polkadot/dev": ^0.61.12
+    "@polkadot/util": ^5.0.2-8
     "@polkadot/wasm-crypto-asmjs": ^3.0.2-11
     "@polkadot/wasm-crypto-wasm": ^3.0.2-11
-    "@polkadot/x-randomvalues": ^5.0.2-7
+    "@polkadot/x-randomvalues": ^5.0.2-8
     override-require: ^1.1.1
   peerDependencies:
     "@polkadot/util": "*"
@@ -1828,30 +1827,30 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/x-randomvalues@npm:^5.0.2-7":
-  version: 5.0.2-7
-  resolution: "@polkadot/x-randomvalues@npm:5.0.2-7"
+"@polkadot/x-randomvalues@npm:^5.0.2-8":
+  version: 5.0.2-8
+  resolution: "@polkadot/x-randomvalues@npm:5.0.2-8"
   dependencies:
     "@babel/runtime": ^7.12.5
-  checksum: 18dc7baf8565e2d52def86b0433e8b6dc9635c1ad1f4dfdb03096ba4f1de8c5e4deaa1ebc0a859deaeab18ecba7fb29d8f7135260f483d51e0beb0137e2c8c0d
+  checksum: 1692917d99b1e397ce3cee7fab287c7924ade28ac3e06169e13cb31dc68c10c6c01b32428b283206ca8e931528cb07f3ed88a4af88a5ff881107e0fc496c517e
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:5.0.2-7":
-  version: 5.0.2-7
-  resolution: "@polkadot/x-textdecoder@npm:5.0.2-7"
+"@polkadot/x-textdecoder@npm:5.0.2-8":
+  version: 5.0.2-8
+  resolution: "@polkadot/x-textdecoder@npm:5.0.2-8"
   dependencies:
     "@babel/runtime": ^7.12.5
-  checksum: e33d0174b8cbc9ba1393d608dbbd2a9e664e6ce2f49313cc8ca35a8b4ff96c8150a0bc3bd4aa476a44974155972b79b886a06daed1a56ba36fe7e31b7814b2bc
+  checksum: b9759a02c078554930cf10f8481102c724765170efcf3ba284dea8b30f5033c443b2823b1fe433821cb2f1102e425361fb350648146f742daeed1845e33fa0ec
   languageName: node
   linkType: hard
 
-"@polkadot/x-textencoder@npm:5.0.2-7":
-  version: 5.0.2-7
-  resolution: "@polkadot/x-textencoder@npm:5.0.2-7"
+"@polkadot/x-textencoder@npm:5.0.2-8":
+  version: 5.0.2-8
+  resolution: "@polkadot/x-textencoder@npm:5.0.2-8"
   dependencies:
     "@babel/runtime": ^7.12.5
-  checksum: a81ba6d03c2a3d8ad63a2b073d7461dfa3758ab1faee8a3f1a047155e639e09624f4f4ef61bbb4fca9b4cc93bba115bb728627f080fb45fdf6a2a3cc714a0644
+  checksum: 77f669c0aaefcb7abea46b79350b74c0e14b463abd17e081b3b3a88658f79d0741b0710d2dbf6ab2b7e05714483ea7976c5396b93f877f7e4787dd69b17d923b
   languageName: node
   linkType: hard
 
@@ -4456,10 +4455,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fflate@npm:^0.4.2":
-  version: 0.4.2
-  resolution: "fflate@npm:0.4.2"
-  checksum: e96c19a1d514f74faa1fe320c022aaf1dade597150510da18dce024ff5a2fa0b6e103daf828fac26c54b647777256638fc7106a3dcff078572b8dee73071df54
+"fflate@npm:^0.4.3":
+  version: 0.4.3
+  resolution: "fflate@npm:0.4.3"
+  checksum: 66e2f3373e65dc1af9206bf3f83b544299b80bc0be3fb62880fa6ffab940c01bb60cf577d751841182112a6b3003d861f286a507c1450074a9aba1afe3062230
   languageName: node
   linkType: hard
 
@@ -8567,7 +8566,8 @@ fsevents@~2.1.2:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@babel/core": ^7.12.10
-    "@polkadot/dev": ^0.61.11
+    "@polkadot/dev": ^0.61.12
+    fflate: ^0.4.3
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This is NOT something that we really want to be doing even medium-term. However, what it does do is that provide a shorter-term solution to https://github.com/polkadot-js/api/issues/2963 and gives some breathing room.

The real first-prize is not having this is just having an upstream fix for the capability.

We could use tiny-inflate instead which may have some saving size-wise (at the cost of speed), but fflate is really well done, so we do want to stick with it. (But also not put undue pressure, aka this solution gives some room to breathe - fully expect it to be really short-term)