### PR TITLE
Adjust `WebAssembly.{Memory, ModuleImports}` usage to cater for non-dom TS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Changes:
 
 - Add missing `peerDependencies` to `wasm-crypto` (`bridge` requirement)
+- Adjust `WebAssembly.{Memory, ModuleImports}` usage to cater for non-dom TS
 
 
 ## 6.1.5 Jun 23, 2022

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",
-    "@polkadot/dev": "^0.67.45",
+    "@polkadot/dev": "^0.67.46",
     "fflate": "^0.7.3",
     "override-require": "^1.1.1"
   },

--- a/packages/wasm-bridge/src/bridge.ts
+++ b/packages/wasm-bridge/src/bridge.ts
@@ -59,11 +59,6 @@ export class Bridge<C extends WasmBaseInstance> implements BridgeBase<C> {
     return this.#type;
   }
 
-  /** @description Returns the created wbg interface */
-  get wbg (): WasmImports {
-    return this.#wbg;
-  }
-
   /** @description Returns the created wasm interface */
   get wasm (): C | null {
     return this.#wasm;

--- a/packages/wasm-bridge/src/bridge.ts
+++ b/packages/wasm-bridge/src/bridge.ts
@@ -7,7 +7,7 @@
 // then ensures that the internal wasm instance here is available
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import type { BridgeBase, InitFn, InitPromise, WasmBaseInstance } from './types';
+import type { BridgeBase, InitFn, InitPromise, WasmBaseInstance, WasmImports } from './types';
 
 import { stringToU8a, u8aToString } from '@polkadot/util';
 
@@ -31,7 +31,7 @@ export class Bridge<C extends WasmBaseInstance> implements BridgeBase<C> {
   #wasm: C | null;
   #wasmError: string | null;
   #wasmPromise: InitPromise<C> | null;
-  #wbg: WebAssembly.ModuleImports;
+  #wbg: WasmImports;
   #type: 'asm' | 'wasm' | 'none';
 
   constructor (createWasm: InitFn<C>) {
@@ -60,7 +60,7 @@ export class Bridge<C extends WasmBaseInstance> implements BridgeBase<C> {
   }
 
   /** @description Returns the created wbg interface */
-  get wbg (): WebAssembly.ModuleImports {
+  get wbg (): WasmImports {
     return this.#wbg;
   }
 

--- a/packages/wasm-bridge/src/init.ts
+++ b/packages/wasm-bridge/src/init.ts
@@ -26,9 +26,7 @@ export function createWasmFn <C extends WasmBaseInstance> (root: string, wasmByt
         throw new Error('WebAssembly is not available in your environment');
       }
 
-      // See the reasoning behind this case in `./types`, we don't use the
-      // actual WebAssebly.ModuleImports types due to some TS oddities
-      const source = await WebAssembly.instantiate(wasmBytes, { wbg } as never);
+      const source = await WebAssembly.instantiate(wasmBytes, { wbg });
 
       result.wasm = source.instance.exports as unknown as C;
       result.type = 'wasm';

--- a/packages/wasm-bridge/src/types.ts
+++ b/packages/wasm-bridge/src/types.ts
@@ -1,6 +1,14 @@
 // Copyright 2019-2022 @polkadot/wasm-bridge authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// Use non-strong types instead of WasmImports which may not
+// be available as part of the TS environment types (it needs dom)
+export type WasmImports = Record<string, (...args: never[]) => unknown>;
+
+// Use non-strong types instead of WebAssembly.Memory which may not
+// be available as part of the TS environment types (it needs dom)
+export type WasmMemory = { buffer: ArrayBuffer };
+
 export declare interface InitResult<C extends WasmBaseInstance> {
   error: string | null;
   type: 'asm' | 'wasm' | 'none';
@@ -9,10 +17,10 @@ export declare interface InitResult<C extends WasmBaseInstance> {
 
 export type InitPromise <C extends WasmBaseInstance> = Promise<InitResult<C>>;
 
-export type InitFn <C extends WasmBaseInstance> = (wbg: WebAssembly.ModuleImports) => InitPromise<C>;
+export type InitFn <C extends WasmBaseInstance> = (wbg: WasmImports) => InitPromise<C>;
 
 export interface BridgeBase<C extends WasmBaseInstance> extends InitResult<C> {
-  wbg: WebAssembly.ModuleImports;
+  wbg: WasmImports;
 
   init (createWasm?: InitFn<C>): Promise<C | null>;
   getObject (idx: number): unknown;
@@ -30,7 +38,7 @@ export interface BridgeBase<C extends WasmBaseInstance> extends InitResult<C> {
 }
 
 export interface WasmBaseInstance {
-  memory: WebAssembly.Memory;
+  memory: WasmMemory;
 
   // wbindgen functions (required and used internally)
 

--- a/packages/wasm-bridge/src/types.ts
+++ b/packages/wasm-bridge/src/types.ts
@@ -20,8 +20,6 @@ export type InitPromise <C extends WasmBaseInstance> = Promise<InitResult<C>>;
 export type InitFn <C extends WasmBaseInstance> = (wbg: WasmImports) => InitPromise<C>;
 
 export interface BridgeBase<C extends WasmBaseInstance> extends InitResult<C> {
-  wbg: WasmImports;
-
   init (createWasm?: InitFn<C>): Promise<C | null>;
   getObject (idx: number): unknown;
   dropObject (idx: number): void;

--- a/packages/wasm-crypto-init/package.json
+++ b/packages/wasm-crypto-init/package.json
@@ -31,9 +31,11 @@
     "@polkadot/wasm-crypto-wasm": "6.1.6-4-x"
   },
   "devDependencies": {
-    "@polkadot/util": "^9.6.2"
+    "@polkadot/util": "^9.6.2",
+    "@polkadot/x-randomvalues": "^9.6.2"
   },
   "peerDependencies": {
-    "@polkadot/util": "*"
+    "@polkadot/util": "*",
+    "@polkadot/x-randomvalues": "*"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1941,9 +1941,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/dev@npm:^0.67.45":
-  version: 0.67.45
-  resolution: "@polkadot/dev@npm:0.67.45"
+"@polkadot/dev@npm:^0.67.46":
+  version: 0.67.46
+  resolution: "@polkadot/dev@npm:0.67.46"
   dependencies:
     "@babel/cli": ^7.18.6
     "@babel/core": ^7.18.6
@@ -2030,7 +2030,7 @@ __metadata:
     polkadot-exec-rollup: scripts/polkadot-exec-rollup.mjs
     polkadot-exec-tsc: scripts/polkadot-exec-tsc.mjs
     polkadot-exec-webpack: scripts/polkadot-exec-webpack.mjs
-  checksum: 0128e457dc980b2fa400809805d703cdedf8c06e301e6c62115709cbe1af3e38cf2d234ef6b949615374963b132f129a8514e608456e0f33c8d53e12777c0622
+  checksum: 94e84748f6756bffbb6de3aa16e94e2a2b72706bc152a00730992c0cb344612dfc15e7f2478e5baea08dc653e17c274bb5b047c3ba29d0b9a248e500c5d1769c
   languageName: node
   linkType: hard
 
@@ -8594,7 +8594,7 @@ resolve@^2.0.0-next.3:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@babel/core": ^7.18.6
-    "@polkadot/dev": ^0.67.45
+    "@polkadot/dev": ^0.67.46
     fflate: ^0.7.3
     override-require: ^1.1.1
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -2083,8 +2083,10 @@ __metadata:
     "@polkadot/wasm-bridge": 6.1.6-4-x
     "@polkadot/wasm-crypto-asmjs": 6.1.6-4-x
     "@polkadot/wasm-crypto-wasm": 6.1.6-4-x
+    "@polkadot/x-randomvalues": ^9.6.2
   peerDependencies:
     "@polkadot/util": "*"
+    "@polkadot/x-randomvalues": "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Allow for use in TS environments where `dom` lib is not present. Since we don't need 100% checks on these (all internal usage, it should be safe without breakages down the line for consumers)

It is out in the wild... https://github.com/polkadot-js/wasm/issues/366