### PR TITLE
ed25519 signing leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## master
+
+Changes:
+
+- Protect against double-sign leak in ed25519 (See https://github.com/MystenLabs/ed25519-unsafe-libs)
+
+
 ## 6.2.1 Jul 1, 2022
 
 Changes:


### PR DESCRIPTION
Since ed25519-dalek is affected, we ensure we don't use that codepath, rather creating the pair directly from the seed and using it for signing.