### PR TITLE
Align tsconfig to allow moduleResolution: nodenext

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,17 +3,17 @@
   "compilerOptions": {
     "composite": true,
     "paths": {
-      "@polkadot/wasm-bridge": ["wasm-bridge/src"],
+      "@polkadot/wasm-bridge": ["wasm-bridge/src/index.ts"],
       "@polkadot/wasm-bridge/*": ["wasm-bridge/src/*.ts"],
-      "@polkadot/wasm-crypto-asmjs": ["wasm-crypto-asmjs/src"],
+      "@polkadot/wasm-crypto-asmjs": ["wasm-crypto-asmjs/src/index.ts"],
       "@polkadot/wasm-crypto-asmjs/*": ["wasm-crypto-asmjs/src/*.ts"],
-      "@polkadot/wasm-crypto-wasm": ["wasm-crypto-wasm/src"],
+      "@polkadot/wasm-crypto-wasm": ["wasm-crypto-wasm/src/index.ts"],
       "@polkadot/wasm-crypto-wasm/*": ["wasm-crypto-wasm/src/*.ts"],
-      "@polkadot/wasm-crypto-init": ["wasm-crypto-init/src/wasm"],
+      "@polkadot/wasm-crypto-init": ["wasm-crypto-init/src/wasm.ts"],
       "@polkadot/wasm-crypto-init/*": ["wasm-crypto-init/src/*.ts"],
-      "@polkadot/wasm-crypto": ["wasm-crypto/src"],
+      "@polkadot/wasm-crypto": ["wasm-crypto/src/index.ts"],
       "@polkadot/wasm-crypto/*": ["wasm-crypto/src/*.ts"],
-      "@polkadot/wasm-util": ["wasm-util/src"],
+      "@polkadot/wasm-util": ["wasm-util/src/index.ts"],
       "@polkadot/wasm-util/*": ["wasm-util/src/*.ts"],
     },
     "skipLibCheck": true


### PR DESCRIPTION
Follow-up for https://github.com/polkadot-js/api/issues/5524 (when we finally enable `"moduleResolution": "nodenext"` in `@polkadot/dev`)