### PR TITLE
Collapse build:mac command into build (w/ detect)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "scripts": {
     "build": "yarn build:wasm",
     "build:js": "./scripts/build-js.sh",
-    "build:mac": "PATH=\"/opt/homebrew/opt/llvm/bin:$PATH\" CC=/opt/homebrew/opt/llvm/bin/clang AR=/opt/homebrew/opt/llvm/bin/llvm-ar yarn build",
     "build:release": "polkadot-ci-ghact-build",
     "build:rollup": "polkadot-exec-rollup --config",
     "build:wasm": "./scripts/build.sh",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,7 +11,19 @@ echo "*** Building JavaScript"
 echo "*** Building WASM"
 cd packages
 
-PKG_NAME=wasm-crypto ../scripts/build-wasm.sh
+unamestr=`uname`
+
+# For Mac we set extra paths for clang
+if [[ "$unamestr" == "Darwin" ]]; then
+  if [ ! -f "/opt/homebrew/opt/llvm/bin/clang" ]; then
+    echo "FATAL: Ensure you have clang installed via homebrew"
+    exit 1
+  fi
+
+  PATH="/opt/homebrew/opt/llvm/bin:$PATH" CC=/opt/homebrew/opt/llvm/bin/clang AR=/opt/homebrew/opt/llvm/bin/llvm-ar PKG_NAME=wasm-crypto ../scripts/build-wasm.sh
+else
+  PKG_NAME=wasm-crypto ../scripts/build-wasm.sh
+fi
 
 if [ -z "$WITH_DENO" ]; then
   yarn test:wasm-crypto:js


### PR DESCRIPTION
... this bit me once again (and certainly would for any contributors), so rather than having 2 seperate commands, we just use platform detection to add the Mac-required flags

As a bonus, we only now detect if the local setup is at least something we do expect