### PR TITLE
ci: add user (TarikGul) to auto-approve

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: jacogr/action-approve@795afd1dd096a2071d7ec98740661af4e853b7da
         with:
-          authors: jacogr
+          authors: jacogr, TarikGul
           labels: -auto
           token: ${{ secrets.GH_PAT_BOT }}


### PR DESCRIPTION
Currently I am not added to the auto-approve authors workflow so I can't trigger a successful auto-approve for simple PR's such as chores, quick fixes, releases, general maintenance, etc. This should help with quicker iteration with simpler work that needs to be done.

What I do not intent to do with auto-approve: Merge complex PR's, breaking changes, and or anything that has a slight unsure element attached to it.