### PR TITLE
chore: Improve CI

### DIFF
--- a/.github/workflows/pr-any.yml
+++ b/.github/workflows/pr-any.yml
@@ -1,6 +1,3 @@
-name: PR
-on: [pull_request]
-
 jobs:
   pr:
     continue-on-error: true
@@ -20,7 +17,7 @@ jobs:
         deno-version: v1.42.x
     - name: ${{ matrix.step }}
       if: always()
-      continue-on-error: true
+      continue-on-error: false
       run: |
         yarn install --immutable
         if [ "${{ matrix.step }}" != "lint" ]; then

--- a/.github/workflows/pr-any.yml
+++ b/.github/workflows/pr-any.yml
@@ -15,6 +15,11 @@ jobs:
     - uses: denoland/setup-deno@v1
       with:
         deno-version: v1.42.x
+    - uses: actions-rs/toolchain@v1 
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
     - name: ${{ matrix.step }}
       if: always()
       continue-on-error: false

--- a/.github/workflows/pr-any.yml
+++ b/.github/workflows/pr-any.yml
@@ -22,7 +22,6 @@ jobs:
         override: true
     - name: ${{ matrix.step }}
       if: always()
-      continue-on-error: false
       run: |
         yarn install --immutable
         if [ "${{ matrix.step }}" != "lint" ]; then

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -25,6 +25,13 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 'lts/*'
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
     - name: Set Execute Permissions
       run: chmod +x ./scripts/*
     - name: Run Install Build Deps


### PR DESCRIPTION
The following PR addresses 2 issues present in the CI
- CI steps may fail on PRs but be marked as successful as it happened in [#579](https://github.com/polkadot-js/wasm/actions/runs/15853881262/job/44694108054#step:5:223).
- Cargo version is outdated and does not support the latest `cargo.lock` format, making the build step of the CI fail.