### PR TITLE
Fix rust version to 1.84

### DIFF
--- a/scripts/rust-version.sh
+++ b/scripts/rust-version.sh
@@ -3,5 +3,5 @@
 # This software may be modified and distributed under the terms
 # of the Apache-2.0 license. See the LICENSE file for details.
 
-RUST_VER=stable
+RUST_VER=1.84
 # RUST_VER=stable


### PR DESCRIPTION
Companion PR for #586. Downgrades the Rust version to a version that supports the current `wasm-bindgen` version